### PR TITLE
Fix deadcode detection and add test cases

### DIFF
--- a/src/plugins/typescript/parser.ts
+++ b/src/plugins/typescript/parser.ts
@@ -679,7 +679,12 @@ export class TypeScriptParser implements ParserPlugin, Disposable {
       }
     }
 
-    // 3. 對於變數、函式和方法，使用作用域檢查
+    // 3. 檢查是否在同一個檔案中
+    if (node.getSourceFile() !== symbolIdentifier.getSourceFile()) {
+      return false;
+    }
+
+    // 4. 對於變數、函式和方法，使用作用域檢查
     const symbolScope = this.getScopeContainer(symbolIdentifier);
     const nodeScope = this.getScopeContainer(node);
 
@@ -689,6 +694,12 @@ export class TypeScriptParser implements ParserPlugin, Disposable {
       if (!this.isShadowed(node, symbolIdentifier)) {
         return true;
       }
+    }
+
+    // 5. 對於頂層函式和變數，放寬檢查條件
+    // 如果符號在頂層作用域（SourceFile），則同一檔案中所有同名標識符都可能是引用
+    if (ts.isSourceFile(symbolScope) && !this.isShadowed(node, symbolIdentifier)) {
+      return true;
     }
 
     return false;

--- a/tests/e2e/cli/ts/cli-deadcode.e2e.test.ts
+++ b/tests/e2e/cli/ts/cli-deadcode.e2e.test.ts
@@ -1,0 +1,529 @@
+/**
+ * CLI dead-code 命令 E2E 測試
+ * 測試各種 deadcode 檢測情況
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { loadFixture, FixtureProject } from '../../helpers/fixture-manager';
+import { executeCLI } from '../../helpers/cli-executor';
+
+describe('CLI dead-code - 基於 deadcode-test fixture', () => {
+  let fixture: FixtureProject;
+
+  beforeEach(async () => {
+    fixture = await loadFixture('deadcode-test');
+  });
+
+  afterEach(async () => {
+    await fixture.cleanup();
+  });
+
+  // ============================================================
+  // 1. 真正的 deadcode 檢測
+  // ============================================================
+
+  describe('真正的 deadcode 檢測', () => {
+    it('應該檢測出未使用的函式', { timeout: 30000 }, async () => {
+      const result = await executeCLI([
+        'analyze',
+        'dead-code',
+        '--path',
+        fixture.getFilePath('src/true-deadcode.ts'),
+        '--format',
+        'json',
+        '--all'
+      ], { timeout: 25000 });
+
+      expect(result.exitCode).toBe(0);
+
+      const output = JSON.parse(result.stdout);
+      const files = output.all || [];
+      const trueDeadcodeFile = files.find((f: any) => f.path.includes('true-deadcode.ts'));
+
+      expect(trueDeadcodeFile).toBeDefined();
+      const deadCode = trueDeadcodeFile.deadCode || [];
+
+      // 應該檢測到 unusedFunction
+      const hasUnusedFunction = deadCode.some((dc: any) =>
+        (dc.name === 'unusedFunction' || dc.symbol === 'unusedFunction') &&
+        (dc.type === 'function' || dc.kind === 'function')
+      );
+      expect(hasUnusedFunction).toBe(true);
+    });
+
+    it('應該檢測出未使用的變數', { timeout: 30000 }, async () => {
+      const result = await executeCLI([
+        'analyze',
+        'dead-code',
+        '--path',
+        fixture.getFilePath('src/true-deadcode.ts'),
+        '--format',
+        'json',
+        '--all'
+      ], { timeout: 25000 });
+
+      expect(result.exitCode).toBe(0);
+
+      const output = JSON.parse(result.stdout);
+      const files = output.all || [];
+      const trueDeadcodeFile = files.find((f: any) => f.path.includes('true-deadcode.ts'));
+
+      expect(trueDeadcodeFile).toBeDefined();
+      const deadCode = trueDeadcodeFile.deadCode || [];
+
+      // 應該檢測到 unusedVariable
+      const hasUnusedVariable = deadCode.some((dc: any) =>
+        (dc.name === 'unusedVariable' || dc.symbol === 'unusedVariable') &&
+        (dc.type === 'variable' || dc.kind === 'variable')
+      );
+      expect(hasUnusedVariable).toBe(true);
+    });
+
+    it('應該檢測出未使用的類別', { timeout: 30000 }, async () => {
+      const result = await executeCLI([
+        'analyze',
+        'dead-code',
+        '--path',
+        fixture.getFilePath('src/true-deadcode.ts'),
+        '--format',
+        'json',
+        '--all'
+      ], { timeout: 25000 });
+
+      expect(result.exitCode).toBe(0);
+
+      const output = JSON.parse(result.stdout);
+      const files = output.all || [];
+      const trueDeadcodeFile = files.find((f: any) => f.path.includes('true-deadcode.ts'));
+
+      expect(trueDeadcodeFile).toBeDefined();
+      const deadCode = trueDeadcodeFile.deadCode || [];
+
+      // 應該檢測到 UnusedClass
+      const hasUnusedClass = deadCode.some((dc: any) =>
+        (dc.name === 'UnusedClass' || dc.symbol === 'UnusedClass') &&
+        (dc.type === 'class' || dc.kind === 'class')
+      );
+      expect(hasUnusedClass).toBe(true);
+    });
+
+    it('應該檢測出未使用的常數', { timeout: 30000 }, async () => {
+      const result = await executeCLI([
+        'analyze',
+        'dead-code',
+        '--path',
+        fixture.getFilePath('src/true-deadcode.ts'),
+        '--format',
+        'json',
+        '--all'
+      ], { timeout: 25000 });
+
+      expect(result.exitCode).toBe(0);
+
+      const output = JSON.parse(result.stdout);
+      const files = output.all || [];
+      const trueDeadcodeFile = files.find((f: any) => f.path.includes('true-deadcode.ts'));
+
+      expect(trueDeadcodeFile).toBeDefined();
+      const deadCode = trueDeadcodeFile.deadCode || [];
+
+      // 應該檢測到 UNUSED_CONSTANT
+      const hasUnusedConstant = deadCode.some((dc: any) =>
+        (dc.name === 'UNUSED_CONSTANT' || dc.symbol === 'UNUSED_CONSTANT')
+      );
+      expect(hasUnusedConstant).toBe(true);
+    });
+  });
+
+  // ============================================================
+  // 2. 不應該誤報的情況
+  // ============================================================
+
+  describe('不應該誤報的情況', () => {
+    it('不應該將 export 的符號標記為 deadcode', { timeout: 30000 }, async () => {
+      const result = await executeCLI([
+        'analyze',
+        'dead-code',
+        '--path',
+        fixture.getFilePath('src/false-positive-cases.ts'),
+        '--format',
+        'json',
+        '--all'
+      ], { timeout: 25000 });
+
+      expect(result.exitCode).toBe(0);
+
+      const output = JSON.parse(result.stdout);
+      const files = output.all || [];
+      const falsePosFile = files.find((f: any) => f.path.includes('false-positive-cases.ts'));
+
+      if (falsePosFile && falsePosFile.deadCode) {
+        const deadCode = falsePosFile.deadCode;
+
+        // 不應該包含 exported 符號
+        const hasExportedFunction = deadCode.some((dc: any) =>
+          dc.name === 'exportedFunction' || dc.symbol === 'exportedFunction'
+        );
+        expect(hasExportedFunction).toBe(false);
+
+        const hasExportedVariable = deadCode.some((dc: any) =>
+          dc.name === 'exportedVariable' || dc.symbol === 'exportedVariable'
+        );
+        expect(hasExportedVariable).toBe(false);
+
+        const hasExportedClass = deadCode.some((dc: any) =>
+          dc.name === 'ExportedClass' || dc.symbol === 'ExportedClass'
+        );
+        expect(hasExportedClass).toBe(false);
+      }
+    });
+
+    it('不應該將內部使用的 helper 函式標記為 deadcode', { timeout: 30000 }, async () => {
+      const result = await executeCLI([
+        'analyze',
+        'dead-code',
+        '--path',
+        fixture.getFilePath('src/true-deadcode.ts'),
+        '--format',
+        'json',
+        '--all'
+      ], { timeout: 25000 });
+
+      expect(result.exitCode).toBe(0);
+
+      const output = JSON.parse(result.stdout);
+      const files = output.all || [];
+      const file = files.find((f: any) => f.path.includes('true-deadcode.ts'));
+
+      if (file && file.deadCode) {
+        const deadCode = file.deadCode;
+
+        // internalHelper 被 publicFunction 使用，不應該是 deadcode
+        const hasInternalHelper = deadCode.some((dc: any) =>
+          dc.name === 'internalHelper' || dc.symbol === 'internalHelper'
+        );
+        expect(hasInternalHelper).toBe(false);
+      }
+    });
+
+    it('不應該將 callback 函式標記為 deadcode', { timeout: 30000 }, async () => {
+      const result = await executeCLI([
+        'analyze',
+        'dead-code',
+        '--path',
+        fixture.getFilePath('src/false-positive-cases.ts'),
+        '--format',
+        'json',
+        '--all'
+      ], { timeout: 25000 });
+
+      expect(result.exitCode).toBe(0);
+
+      const output = JSON.parse(result.stdout);
+      const files = output.all || [];
+      const file = files.find((f: any) => f.path.includes('false-positive-cases.ts'));
+
+      if (file && file.deadCode) {
+        const deadCode = file.deadCode;
+
+        // dataHandler 被用作 callback，不應該是 deadcode
+        const hasDataHandler = deadCode.some((dc: any) =>
+          dc.name === 'dataHandler' || dc.symbol === 'dataHandler'
+        );
+        expect(hasDataHandler).toBe(false);
+      }
+    });
+
+    it('不應該將遞迴函式標記為 deadcode', { timeout: 30000 }, async () => {
+      const result = await executeCLI([
+        'analyze',
+        'dead-code',
+        '--path',
+        fixture.getFilePath('src/false-positive-cases.ts'),
+        '--format',
+        'json',
+        '--all'
+      ], { timeout: 25000 });
+
+      expect(result.exitCode).toBe(0);
+
+      const output = JSON.parse(result.stdout);
+      const files = output.all || [];
+      const file = files.find((f: any) => f.path.includes('false-positive-cases.ts'));
+
+      if (file && file.deadCode) {
+        const deadCode = file.deadCode;
+
+        // recursiveFunction 被 factorial 使用，不應該是 deadcode
+        const hasRecursive = deadCode.some((dc: any) =>
+          dc.name === 'recursiveFunction' || dc.symbol === 'recursiveFunction'
+        );
+        expect(hasRecursive).toBe(false);
+      }
+    });
+  });
+
+  // ============================================================
+  // 3. 類別成員的檢測
+  // ============================================================
+
+  describe('類別成員的 deadcode 檢測', () => {
+    it('不應該將 public 成員標記為 deadcode', { timeout: 30000 }, async () => {
+      const result = await executeCLI([
+        'analyze',
+        'dead-code',
+        '--path',
+        fixture.getFilePath('src/class-members.ts'),
+        '--format',
+        'json',
+        '--all'
+      ], { timeout: 25000 });
+
+      expect(result.exitCode).toBe(0);
+
+      const output = JSON.parse(result.stdout);
+      const files = output.all || [];
+      const file = files.find((f: any) => f.path.includes('class-members.ts'));
+
+      if (file && file.deadCode) {
+        const deadCode = file.deadCode;
+
+        // public 成員不應該被標記為 deadcode
+        const hasPublicMethod = deadCode.some((dc: any) =>
+          dc.name === 'publicMethod' || dc.symbol === 'publicMethod'
+        );
+        expect(hasPublicMethod).toBe(false);
+      }
+    });
+
+    it('不應該將 protected 成員標記為 deadcode', { timeout: 30000 }, async () => {
+      const result = await executeCLI([
+        'analyze',
+        'dead-code',
+        '--path',
+        fixture.getFilePath('src/class-members.ts'),
+        '--format',
+        'json',
+        '--all'
+      ], { timeout: 25000 });
+
+      expect(result.exitCode).toBe(0);
+
+      const output = JSON.parse(result.stdout);
+      const files = output.all || [];
+      const file = files.find((f: any) => f.path.includes('class-members.ts'));
+
+      if (file && file.deadCode) {
+        const deadCode = file.deadCode;
+
+        // protected 成員不應該被標記為 deadcode
+        const hasProtectedMethod = deadCode.some((dc: any) =>
+          dc.name === 'protectedMethod' || dc.symbol === 'protectedMethod'
+        );
+        expect(hasProtectedMethod).toBe(false);
+      }
+    });
+
+    it('應該檢測未使用的 private 成員', { timeout: 30000 }, async () => {
+      const result = await executeCLI([
+        'analyze',
+        'dead-code',
+        '--path',
+        fixture.getFilePath('src/class-members.ts'),
+        '--format',
+        'json',
+        '--all'
+      ], { timeout: 25000 });
+
+      expect(result.exitCode).toBe(0);
+
+      const output = JSON.parse(result.stdout);
+      const files = output.all || [];
+      const file = files.find((f: any) => f.path.includes('class-members.ts'));
+
+      if (file && file.deadCode) {
+        const deadCode = file.deadCode;
+
+        // unusedPrivateMethod 應該被檢測為 deadcode
+        const hasUnusedPrivate = deadCode.some((dc: any) =>
+          dc.name === 'unusedPrivateMethod' || dc.symbol === 'unusedPrivateMethod'
+        );
+        expect(hasUnusedPrivate).toBe(true);
+      }
+    });
+
+    it('不應該將已使用的 private 成員標記為 deadcode', { timeout: 30000 }, async () => {
+      const result = await executeCLI([
+        'analyze',
+        'dead-code',
+        '--path',
+        fixture.getFilePath('src/class-members.ts'),
+        '--format',
+        'json',
+        '--all'
+      ], { timeout: 25000 });
+
+      expect(result.exitCode).toBe(0);
+
+      const output = JSON.parse(result.stdout);
+      const files = output.all || [];
+      const file = files.find((f: any) => f.path.includes('class-members.ts'));
+
+      if (file && file.deadCode) {
+        const deadCode = file.deadCode;
+
+        // usedPrivateMethod 被 callPrivate 使用，不應該是 deadcode
+        const hasUsedPrivate = deadCode.some((dc: any) =>
+          dc.name === 'usedPrivateMethod' || dc.symbol === 'usedPrivateMethod'
+        );
+        expect(hasUsedPrivate).toBe(false);
+      }
+    });
+  });
+
+  // ============================================================
+  // 4. 複雜引用關係的檢測
+  // ============================================================
+
+  describe('複雜引用關係的檢測', () => {
+    it('不應該將物件屬性引用的函式標記為 deadcode', { timeout: 30000 }, async () => {
+      const result = await executeCLI([
+        'analyze',
+        'dead-code',
+        '--path',
+        fixture.getFilePath('src/complex-references.ts'),
+        '--format',
+        'json',
+        '--all'
+      ], { timeout: 25000 });
+
+      expect(result.exitCode).toBe(0);
+
+      const output = JSON.parse(result.stdout);
+      const files = output.all || [];
+      const file = files.find((f: any) => f.path.includes('complex-references.ts'));
+
+      if (file && file.deadCode) {
+        const deadCode = file.deadCode;
+
+        // helperFunction 透過物件屬性引用，不應該是 deadcode
+        const hasHelperFunction = deadCode.some((dc: any) =>
+          dc.name === 'helperFunction' || dc.symbol === 'helperFunction'
+        );
+        expect(hasHelperFunction).toBe(false);
+      }
+    });
+
+    it('不應該將陣列元素引用的函式標記為 deadcode', { timeout: 30000 }, async () => {
+      const result = await executeCLI([
+        'analyze',
+        'dead-code',
+        '--path',
+        fixture.getFilePath('src/complex-references.ts'),
+        '--format',
+        'json',
+        '--all'
+      ], { timeout: 25000 });
+
+      expect(result.exitCode).toBe(0);
+
+      const output = JSON.parse(result.stdout);
+      const files = output.all || [];
+      const file = files.find((f: any) => f.path.includes('complex-references.ts'));
+
+      if (file && file.deadCode) {
+        const deadCode = file.deadCode;
+
+        // arrayHelper 作為陣列元素，不應該是 deadcode
+        const hasArrayHelper = deadCode.some((dc: any) =>
+          dc.name === 'arrayHelper' || dc.symbol === 'arrayHelper'
+        );
+        expect(hasArrayHelper).toBe(false);
+      }
+    });
+
+    it('應該檢測從未被引用的函式', { timeout: 30000 }, async () => {
+      const result = await executeCLI([
+        'analyze',
+        'dead-code',
+        '--path',
+        fixture.getFilePath('src/complex-references.ts'),
+        '--format',
+        'json',
+        '--all'
+      ], { timeout: 25000 });
+
+      expect(result.exitCode).toBe(0);
+
+      const output = JSON.parse(result.stdout);
+      const files = output.all || [];
+      const file = files.find((f: any) => f.path.includes('complex-references.ts'));
+
+      if (file && file.deadCode) {
+        const deadCode = file.deadCode;
+
+        // neverReferencedFunction 應該被檢測為 deadcode
+        const hasNeverReferenced = deadCode.some((dc: any) =>
+          dc.name === 'neverReferencedFunction' || dc.symbol === 'neverReferencedFunction'
+        );
+        expect(hasNeverReferenced).toBe(true);
+      }
+    });
+  });
+
+  // ============================================================
+  // 5. 輸出格式測試
+  // ============================================================
+
+  describe('輸出格式測試', () => {
+    it('預設應該只輸出有 deadcode 的檔案', { timeout: 30000 }, async () => {
+      const result = await executeCLI([
+        'analyze',
+        'dead-code',
+        '--path',
+        fixture.tempPath,
+        '--format',
+        'json'
+        // 不加 --all
+      ], { timeout: 25000 });
+
+      expect(result.exitCode).toBe(0);
+
+      const output = JSON.parse(result.stdout);
+
+      // 預設應該只有 issues，沒有 all
+      expect(output.issues).toBeDefined();
+      expect(output.all).toBeUndefined();
+      expect(output.summary).toBeDefined();
+
+      // issues 只包含有 deadcode 的檔案
+      for (const file of output.issues) {
+        expect(file.deadCode.length).toBeGreaterThan(0);
+      }
+    });
+
+    it('--all 應該輸出所有掃描的檔案', { timeout: 30000 }, async () => {
+      const result = await executeCLI([
+        'analyze',
+        'dead-code',
+        '--path',
+        fixture.tempPath,
+        '--format',
+        'json',
+        '--all'
+      ], { timeout: 25000 });
+
+      expect(result.exitCode).toBe(0);
+
+      const output = JSON.parse(result.stdout);
+
+      // --all 應該有 all 和 issues
+      expect(output.all).toBeDefined();
+      expect(output.issues).toBeDefined();
+      expect(output.summary).toBeDefined();
+
+      // all 包含所有檔案（包括沒有 deadcode 的）
+      expect(output.all.length).toBeGreaterThanOrEqual(output.issues.length);
+    });
+  });
+});

--- a/tests/fixtures/deadcode-test/package.json
+++ b/tests/fixtures/deadcode-test/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "deadcode-test",
+  "version": "1.0.0",
+  "type": "module"
+}

--- a/tests/fixtures/deadcode-test/src/class-members.ts
+++ b/tests/fixtures/deadcode-test/src/class-members.ts
@@ -1,0 +1,72 @@
+/**
+ * 類別成員的 deadcode 檢測測試
+ */
+
+export class TestClass {
+  // ❌ 非 DEADCODE: public 屬性可能被外部訪問
+  public publicProp: string = 'public';
+
+  // ❌ 非 DEADCODE: protected 屬性可能被子類別使用
+  protected protectedProp: string = 'protected';
+
+  // ✅ DEADCODE: private 屬性未被使用
+  private unusedPrivateProp: string = 'unused';
+
+  // ❌ 非 DEADCODE: private 屬性有被使用
+  private usedPrivateProp: string = 'used';
+
+  constructor() {
+    // 使用 usedPrivateProp
+    console.log(this.usedPrivateProp);
+  }
+
+  // ❌ 非 DEADCODE: public 方法
+  public publicMethod() {
+    return this.publicProp;
+  }
+
+  // ❌ 非 DEADCODE: protected 方法
+  protected protectedMethod() {
+    return this.protectedProp;
+  }
+
+  // ✅ DEADCODE: private 方法未被使用
+  private unusedPrivateMethod() {
+    return 'unused';
+  }
+
+  // ❌ 非 DEADCODE: private 方法有被使用
+  private usedPrivateMethod() {
+    return 'used';
+  }
+
+  public callPrivate() {
+    return this.usedPrivateMethod();
+  }
+}
+
+// ❌ 非 DEADCODE: 子類別繼承
+export class DerivedClass extends TestClass {
+  useProtected() {
+    return this.protectedMethod(); // 使用父類別的 protected 方法
+  }
+}
+
+// ✅ DEADCODE: 未使用的內部類別
+class UnusedInternalClass {
+  method() {
+    return 'internal';
+  }
+}
+
+// ❌ 非 DEADCODE: 有被使用的內部類別
+class UsedInternalClass {
+  method() {
+    return 'used internal';
+  }
+}
+
+export function useInternalClass() {
+  const instance = new UsedInternalClass();
+  return instance.method();
+}

--- a/tests/fixtures/deadcode-test/src/complex-references.ts
+++ b/tests/fixtures/deadcode-test/src/complex-references.ts
@@ -1,0 +1,85 @@
+/**
+ * 複雜引用關係的測試
+ */
+
+// ❌ 非 DEADCODE: 透過物件屬性引用
+function helperFunction() {
+  return 'helper';
+}
+
+export const config = {
+  handler: helperFunction // 透過物件屬性引用
+};
+
+// ❌ 非 DEADCODE: 作為陣列元素
+function arrayHelper() {
+  return 'array';
+}
+
+export const handlers = [arrayHelper];
+
+// ❌ 非 DEADCODE: 作為高階函式參數
+function mapper(item: string) {
+  return item.toUpperCase();
+}
+
+export function processItems(items: string[]) {
+  return items.map(mapper);
+}
+
+// ❌ 非 DEADCODE: 解構賦值
+function getValue() {
+  return { data: 'value' };
+}
+
+export function useDestructuring() {
+  const { data } = getValue();
+  return data;
+}
+
+// ✅ DEADCODE: 函式定義但從未被引用
+function neverReferencedFunction() {
+  return 'never used';
+}
+
+// ✅ DEADCODE: 變數定義但從未被引用
+const neverReferencedVariable = 'never used';
+
+// ❌ 非 DEADCODE: 型別守衛函式
+function isString(value: unknown): value is string {
+  return typeof value === 'string';
+}
+
+export function checkType(value: unknown) {
+  if (isString(value)) {
+    return value.toUpperCase();
+  }
+  return String(value);
+}
+
+// ❌ 非 DEADCODE: 工廠函式
+function createHandler(type: string) {
+  return () => `handler for ${type}`;
+}
+
+export function getHandler(type: string) {
+  return createHandler(type);
+}
+
+// ✅ DEADCODE: 未完成的實作
+function todoImplementation() {
+  // TODO: implement this
+  return null;
+}
+
+// ❌ 非 DEADCODE: 條件性使用
+function conditionalHelper(flag: boolean) {
+  return flag ? 'yes' : 'no';
+}
+
+export function conditional(flag: boolean) {
+  if (flag) {
+    return conditionalHelper(flag);
+  }
+  return 'default';
+}

--- a/tests/fixtures/deadcode-test/src/false-positive-cases.ts
+++ b/tests/fixtures/deadcode-test/src/false-positive-cases.ts
@@ -1,0 +1,103 @@
+/**
+ * 這個文件包含不應該被檢測為 deadcode 的情況（false positive cases）
+ */
+
+// ❌ 非 DEADCODE: exported 符號應該被忽略
+export function exportedFunction() {
+  return 'exported';
+}
+
+export const exportedVariable = 'exported variable';
+
+export class ExportedClass {
+  constructor() {}
+}
+
+// ❌ 非 DEADCODE: 類別方法被外部調用
+export class ServiceClass {
+  // public 方法可能被外部調用
+  public publicMethod() {
+    return this.privateHelper();
+  }
+
+  // private 方法被內部使用，不是 deadcode
+  private privateHelper() {
+    return 'helper';
+  }
+
+  // protected 方法可能被子類別使用
+  protected protectedMethod() {
+    return 'protected';
+  }
+}
+
+// ❌ 非 DEADCODE: 鏈式調用
+export class ChainClass {
+  private value: number = 0;
+
+  setValue(val: number) {
+    this.value = val;
+    return this;
+  }
+
+  getValue() {
+    return this.value;
+  }
+}
+
+// ❌ 非 DEADCODE: callback 函式
+export function processData(callback: (data: string) => void) {
+  callback('data');
+}
+
+function dataHandler(data: string) {
+  console.log(data);
+}
+
+export function setupHandler() {
+  processData(dataHandler); // dataHandler 被使用
+}
+
+// ❌ 非 DEADCODE: 物件方法引用
+export const handlers = {
+  handle1: function handleOne() {
+    return 'one';
+  },
+  handle2: function handleTwo() {
+    return 'two';
+  }
+};
+
+// ❌ 非 DEADCODE: 動態調用
+function dynamicFunction() {
+  return 'dynamic';
+}
+
+export function callDynamic(name: string) {
+  if (name === 'dynamicFunction') {
+    return dynamicFunction();
+  }
+}
+
+// ❌ 非 DEADCODE: 遞迴函式
+function recursiveFunction(n: number): number {
+  if (n <= 1) {return 1;}
+  return n * recursiveFunction(n - 1);
+}
+
+export function factorial(n: number) {
+  return recursiveFunction(n);
+}
+
+// ❌ 非 DEADCODE: 互相調用的函式
+function helperA() {
+  return helperB();
+}
+
+function helperB() {
+  return 'result';
+}
+
+export function useHelpers() {
+  return helperA();
+}

--- a/tests/fixtures/deadcode-test/src/true-deadcode.ts
+++ b/tests/fixtures/deadcode-test/src/true-deadcode.ts
@@ -1,0 +1,56 @@
+/**
+ * 這個文件包含真正的 deadcode（未使用的符號）
+ */
+
+// ✅ DEADCODE: 未使用的函式
+function unusedFunction() {
+  return 'This function is never called';
+}
+
+// ✅ DEADCODE: 未使用的變數
+const unusedVariable = 'This variable is never referenced';
+
+// ✅ DEADCODE: 未使用的類別
+class UnusedClass {
+  private data: string;
+
+  constructor(data: string) {
+    this.data = data;
+  }
+
+  getData() {
+    return this.data;
+  }
+}
+
+// ✅ DEADCODE: 未使用的常數
+const UNUSED_CONSTANT = 42;
+
+// ✅ DEADCODE: 未使用的箭頭函式
+const unusedArrowFunction = () => {
+  return 'arrow function';
+};
+
+// ✅ DEADCODE: 未使用的 async 函式
+async function unusedAsyncFunction() {
+  return Promise.resolve('async result');
+}
+
+// ✅ DEADCODE: 未使用的泛型函式
+function unusedGenericFunction<T>(value: T): T {
+  return value;
+}
+
+// ❌ 非 DEADCODE: 已使用的函式
+export function usedFunction() {
+  return 'This function is exported and used';
+}
+
+// ❌ 非 DEADCODE: 內部使用的函式
+function internalHelper() {
+  return 'helper';
+}
+
+export function publicFunction() {
+  return internalHelper(); // 使用了 internalHelper
+}


### PR DESCRIPTION
## 問題
- deadcode 檢測結果不正確
- 對於頂層函式和變數的引用識別過於嚴格
- 物件屬性引用、陣列元素引用等情況無法正確識別

## 修復內容

### 1. 改進符號引用檢測邏輯 (src/plugins/typescript/parser.ts)
- 放寬對頂層作用域符號的檢查條件
- 對於在 SourceFile 作用域中的符號，同一檔案中所有同名標識符都視為可能的引用
- 保留遮蔽檢查以避免誤報

### 2. 新增全面的測試 fixture (tests/fixtures/deadcode-test/) 包含四個測試文件，涵蓋各種情況：

**true-deadcode.ts** - 真正的 deadcode：
- 未使用的函式、變數、類別、常數
- 未使用的 async 函式和泛型函式
- 已使用的 export 函式和內部 helper

**false-positive-cases.ts** - 不應誤報的情況：
- exported 符號
- callback 函式
- 遞迴函式
- 鏈式調用
- 動態調用

**class-members.ts** - 類別成員檢測：
- public/protected 成員（不應報為 deadcode）
- private 成員（未使用時應檢測）
- 繼承關係

**complex-references.ts** - 複雜引用關係：
- 物件屬性引用
- 陣列元素引用
- 高階函式參數
- 解構賦值
- 型別守衛
- 工廠函式

### 3. 新增詳細的 E2E 測試 (tests/e2e/cli/ts/cli-deadcode.e2e.test.ts) 17 個測試用例，涵蓋：
- 真正的 deadcode 檢測（函式、變數、類別、常數）
- 不應誤報的情況（export、callback、遞迴等）
- 類別成員檢測（public/protected/private）
- 複雜引用關係（物件屬性、陣列元素等）
- 輸出格式（預設/--all 參數）

## 測試驗證
- 所有新增測試通過
- 能正確識別真正的 deadcode
- 能正確排除有引用的符號
- 能處理各種複雜引用情況