### PR TITLE
refactor: ReferenceUpdater 使用 SymbolFinder 統一引用查找邏輯

### DIFF
--- a/src/core/rename/reference-updater.ts
+++ b/src/core/rename/reference-updater.ts
@@ -131,7 +131,12 @@ export class ReferenceUpdater {
       try {
         const refs = await this.symbolFinder.findReferencesInFile(filePath, symbolName);
 
-        // 轉換 SymbolFinder 的 SymbolReference 為本地型別
+        // 轉換 SymbolFinder 的 SymbolReference (@core/shared/symbol-finder)
+        // 為本地型別 SymbolReference (@core/rename/types)
+        // 兩者差異：
+        // - SymbolFinder 版本：{ symbolName, location: Location, type: SymbolReferenceType }
+        // - 本地版本：{ symbolName, range: Range, type: 'definition' | 'usage' | 'comment' }
+        // filePath 資訊已知（來自方法參數），故只需映射 range 和 type
         return refs.map(ref => ({
           symbolName,
           range: ref.location.range,
@@ -149,6 +154,9 @@ export class ReferenceUpdater {
 
   /**
    * 映射 SymbolFinder 的引用類型到本地類型
+   *
+   * 注意：'comment' 類型只會從降級方法 findSymbolReferencesByText 產生，
+   * 不會經過此映射函式。SymbolReferenceType enum 目前沒有 Comment 類型。
    */
   private mapReferenceType(type: SymbolReferenceType): 'definition' | 'usage' | 'comment' {
     switch (type) {


### PR DESCRIPTION
## Summary

- ReferenceUpdater 改用 SymbolFinder 進行符號引用查找，消除重複的 AST 分析邏輯
- 減少約 50 行重複程式碼（-48, +35）
- 保留 findSymbolReferencesByText 作為降級方法，確保向後相容

## 背景

`ReferenceUpdater.findSymbolReferences()` 與 `SymbolFinder.findReferencesInFile()` 功能重複：
- 都使用 Parser 的 AST 分析
- 都有文字匹配降級機制
- 都回傳符號位置資訊

## 變更內容

1. 引入 `SymbolFinder` 依賴
2. 在 constructor 中創建 `SymbolFinder` 實例
3. `findSymbolReferences()` 委託 `SymbolFinder.findReferencesInFile()`
4. 新增 `mapReferenceType()` 處理型別轉換

## Test plan

- [x] typecheck 通過
- [x] lint 通過（僅既有 warnings）
- [x] 533 個 E2E 測試全部通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)